### PR TITLE
Add interests to schema

### DIFF
--- a/tap_mailchimp/schemas/lists_members.json
+++ b/tap_mailchimp/schemas/lists_members.json
@@ -67,6 +67,12 @@
           "object"
         ]
       },
+      "interests": {
+        "type": [
+          "null",
+          "object"
+        ]
+      },
       "stats": {
         "type": [
           "null",


### PR DESCRIPTION
As per discussion, this adds interests to the schema which allows them to be pulled down just like merge fields. 

Probably if you want to make this more fancy you should have a look at the interests api and pull down the interest-categories as another stream.

https://{dc}.api.mailchimp.com/3.0/lists/{listid}/interest-categories

And then pull down the interests in each interest category
https://{dc}.api.mailchimp.com/3.0/lists/{listid}/interest-categories/{categoryid}/interests
